### PR TITLE
Accept ISBNs with spaces in them

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2,6 +2,9 @@ const getIsbnCodes = require('./get_isbn_codes')
 
 module.exports = function (value) {
   value = value.toString()
+  if (!value) return null
+
+  value = value.replace(/\s/g, '')
 
   var data = getIsbnCodes(value)
   if (!data) return null

--- a/test/hyphenate.js
+++ b/test/hyphenate.js
@@ -13,6 +13,12 @@ describe('hyphenate', () => {
     done()
   })
 
+  it('hyphenates ISBN13s with spaces', done => {
+    hyphenate('978 4873113364').should.equal('978-4-87311-336-4')
+    hyphenate('979 1091146135').should.equal('979-10-91146-13-5')
+    done()
+  })
+
   it('does not refuse hyphenated ISBNs', done => {
     hyphenate('4-87311-336-9').should.equal('4-87311-336-9')
     hyphenate('978-4-87311-336-4').should.equal('978-4-87311-336-4')

--- a/test/parse.js
+++ b/test/parse.js
@@ -5,6 +5,7 @@ describe('parse', () => {
   it('returns an object with all the data when valid', done => {
     parse('9791091146135').isValid.should.be.true()
     parse('979-1091146135').isValid.should.be.true()
+    parse('979 1091146135').isValid.should.be.true()
     done()
   })
 


### PR DESCRIPTION
ISBN 13s are commonly formatted with a space
in between the first three digits and the last
10. This change strips all spaces from any input so
these will be valid.

Adds tests.