### PR TITLE
readme: fix update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ npm test
 
 ### Update Groups
 
-To get the latest ISBN groups from [isbn-international.org], use:
+To get the latest ISBN groups from [isbn-international.org](https://isbn-international.org), use:
 
 ```sh
-npm run get-groups
+npm run update-groups
 ```
 
 Results will be saved as a JavaScript object in `./groups.js`


### PR DESCRIPTION
`package.json` defines `update-groups`, not `get-groups`. And also fix the link while we’re at it (it wasn’t showing correctly on GitHub).