### PR TITLE
allow checksum X for isbn10

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Valid ISBN input examples:
 - 978-1491574317
 - isbn:9781491574317
 - 9781-hello-491574317
+- 030433376X
+- 0-304-33376-X
 
 Formats:
 - h: hyphen

--- a/test/as_isbn_10.js
+++ b/test/as_isbn_10.js
@@ -7,8 +7,13 @@ describe('asIsbn10', () => {
     done()
   })
 
-  it('accepts ISBN10 as well', done => {
+  it('accepts ISBN10', done => {
     asIsbn10('4-87311-336-9').should.equal('4873113369')
+    done()
+  })
+
+  it('accepts ISBN10 with checksum X', done => {
+    asIsbn10('0-304-33376-X').should.equal('030433376X')
     done()
   })
 
@@ -27,10 +32,5 @@ describe('asIsbn10', () => {
       should(asIsbn10('9791091146135')).not.be.ok()
       done()
     })
-  })
-
-  it('accepts ISBN10 with Checksum X', done => {
-    asIsbn10('0-304-33376-X').should.equal('030433376X')
-    done()
   })
 })

--- a/test/as_isbn_10.js
+++ b/test/as_isbn_10.js
@@ -28,4 +28,9 @@ describe('asIsbn10', () => {
       done()
     })
   })
+
+  it('accepts ISBN10 with Checksum X', done => {
+    asIsbn10('0-304-33376-X').should.equal('030433376X')
+    done()
+  })
 })

--- a/test/as_isbn_13.js
+++ b/test/as_isbn_13.js
@@ -21,4 +21,9 @@ describe('asIsbn13', () => {
     should(asIsbn13('4873113361')).not.be.ok()
     done()
   })
+
+  it('accepts ISBN10 with Checksum X', done => {
+    asIsbn13('0-304-33376-X').should.equal('9780304333769')
+    done()
+  })
 })

--- a/test/as_isbn_13.js
+++ b/test/as_isbn_13.js
@@ -7,7 +7,12 @@ describe('asIsbn13', () => {
     done()
   })
 
-  it('accepts ISBN13 as well', done => {
+  it('accepts ISBN10 with checksum X', done => {
+    asIsbn13('0-304-33376-X').should.equal('9780304333769')
+    done()
+  })
+
+  it('accepts ISBN13', done => {
     asIsbn13('978-4-87311-336-4').should.equal('9784873113364')
     done()
   })
@@ -19,11 +24,6 @@ describe('asIsbn13', () => {
 
   it('returns null if ISBN is invalid', done => {
     should(asIsbn13('4873113361')).not.be.ok()
-    done()
-  })
-
-  it('accepts ISBN10 with Checksum X', done => {
-    asIsbn13('0-304-33376-X').should.equal('9780304333769')
     done()
   })
 })

--- a/test/hyphenate.js
+++ b/test/hyphenate.js
@@ -7,6 +7,11 @@ describe('hyphenate', () => {
     done()
   })
 
+  it('hyphenates ISBN10s with checksum X', done => {
+    hyphenate('030433376X').should.equal('0-304-33376-X')
+    done()
+  })
+
   it('hyphenates ISBN13s', done => {
     hyphenate('9784873113364').should.equal('978-4-87311-336-4')
     hyphenate('9791091146135').should.equal('979-10-91146-13-5')
@@ -28,11 +33,6 @@ describe('hyphenate', () => {
   it('returns null for non-valid ISBN', done => {
     should(hyphenate('4873113360')).not.be.ok()
     should(hyphenate('9784873113360')).not.be.ok()
-    done()
-  })
-
-  it('hyphenates ISBN10s with Checksum X', done => {
-    hyphenate('030433376X').should.equal('0-304-33376-X')
     done()
   })
 })

--- a/test/hyphenate.js
+++ b/test/hyphenate.js
@@ -30,4 +30,9 @@ describe('hyphenate', () => {
     should(hyphenate('9784873113360')).not.be.ok()
     done()
   })
+
+  it('hyphenates ISBN10s with Checksum X', done => {
+    hyphenate('030433376X').should.equal('0-304-33376-X')
+    done()
+  })
 })

--- a/test/parse.js
+++ b/test/parse.js
@@ -72,7 +72,7 @@ describe('parse', () => {
     })
   })
 
-  describe('given an ISBN10 with Checksum X', () => {
+  describe('given an ISBN10 with checksum X', () => {
     const isbnData = parse('0-304-33376-X')
 
     it('detects ISBN standard', done => {

--- a/test/parse.js
+++ b/test/parse.js
@@ -72,6 +72,60 @@ describe('parse', () => {
     })
   })
 
+  describe('given an ISBN10 with Checksum X', () => {
+    const isbnData = parse('0-304-33376-X')
+
+    it('detects ISBN standard', done => {
+      isbnData.isIsbn10.should.be.true()
+      isbnData.isIsbn13.should.be.false()
+      done()
+    })
+
+    it('includes source', done => {
+      isbnData.source.should.equal('0-304-33376-X')
+      done()
+    })
+
+    it('does not include prefix', done => {
+      should(isbnData.prefix).not.be.ok()
+      done()
+    })
+
+    it('includes group id', done => {
+      isbnData.group.should.equal('0')
+      done()
+    })
+
+    it('includes group name', done => {
+      isbnData.groupname.should.equal('English language')
+      done()
+    })
+
+    it('includes publisher id', done => {
+      isbnData.publisher.should.equal('304')
+      done()
+    })
+
+    it('includes article id', done => {
+      isbnData.article.should.equal('33376')
+      done()
+    })
+
+    it('includes check digits for ISBN10/13', done => {
+      isbnData.check10.should.equal('X')
+      isbnData.check13.should.equal('9')
+      done()
+    })
+
+    it('includes plain and hyphenated versions of ISBN10/13', done => {
+      isbnData.isbn10.should.equal('030433376X')
+      isbnData.isbn10h.should.equal('0-304-33376-X')
+      isbnData.isbn13.should.equal('9780304333769')
+      isbnData.isbn13h.should.equal('978-0-304-33376-9')
+      done()
+    })
+  })
+
   describe('given an ISBN13', () => {
     const isbnData = parse('978-3-642-38745-6')
 


### PR DESCRIPTION
According to Wikipedia page https://en.wikipedia.org/wiki/International_Standard_Book_Number :

> The method for the 10-digit ISBN is an extension of that for SBNs, so the two systems are compatible; an SBN prefixed with a zero (the 10-digit ISBN) will give the same check digit as the SBN without the zero. The check digit is base eleven, and can be an integer between 0 and 9, or an 'X'.