### PR TITLE
feat: add audit to preview link

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
       padding: 1em;
       max-width: 30em;
       margin: 1em 0;
+      white-space: pre-wrap;
     }
     .no-js{
       color: red;
@@ -38,7 +39,13 @@
   <div class="control">
     ISBN: <input id="isbnInput" type="text" value="9781781682135" />
   </div>
+
+  <sub>result:</sub>
   <pre id="result"></pre>
+
+  <sub>audit:</sub>
+  <pre id="audit"></pre>
+
   <noscript>
     <p class="no-js">This demo requires javascript</p>
   </noscript>
@@ -62,7 +69,8 @@
       lastValue = currentValue
 
       if (currentValue === '') {
-        result.innerHTML = ''
+        result.innerHTML = 'Missing ISBN'
+        audit.innerHTML = 'Missing ISBN'
         return
       }
 
@@ -72,6 +80,8 @@
       } else {
         result.innerHTML = 'invalid ISBN'
       }
+      const isbnAudit = ISBN.audit(currentValue)
+      audit.innerHTML = JSON.stringify(isbnAudit, null, 2)
       updateQueryString(currentValue)
     }
 


### PR DESCRIPTION
The new audit function is really nice and already helped me in some situations, sending this PR to make it easier to share a "link" with the audit results using the existing preview page.

Example:

![image](https://github.com/user-attachments/assets/8523dd16-0a66-4824-b185-084ef409e484)

Success:

![image](https://github.com/user-attachments/assets/a9838b8c-8ddc-4c03-8b69-1114e4094751)

Missing:

![image](https://github.com/user-attachments/assets/bdf5d4bb-36ea-4aa2-bec5-439b1fbb87e2)


