### PR TITLE
fix: function signatures

### DIFF
--- a/isbn.d.ts
+++ b/isbn.d.ts
@@ -30,8 +30,8 @@ interface ISBN {
 
 declare module "isbn3" {
   export function parse(isbn: string): ISBN | null;
-  export function asIsbn13(isbn: string): string;
-  export function asIsbn10(isbn: string): string;
+  export function asIsbn13(isbn: string): string | null;
+  export function asIsbn10(isbn: string): string | null;
   export function hyphenate(isbn: string): string;
   export function audit(isbn: string): ISBNAudit;
   export const groups: Record<


### PR DESCRIPTION
It seems the functions `asIsbn10` and `asIsbn13` can return `null`, but this is not reflected in the type signature.