### PR TITLE
Updated badge for GitHub workflow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Added features compared to `isbn2`:
 
 [![NPM](https://nodei.co/npm/isbn3.png?stars&downloads&downloadRank)](https://npmjs.com/package/isbn3/)
 
-![Auto-update groups data](https://github.com/inventaire/isbn3/workflows/Update%20groups%20and%20publish/badge.svg)
+![Auto-update groups data](https://github.com/inventaire/isbn3/actions/workflows/auto_update_groups_data.yml/badge.svg)
 
 ## Summary
 


### PR DESCRIPTION
The badge for the status of the GitHub workflow that automatically updates the groups was not working. Perhaps GitHub changed the URL for getting the correct badge. The current documentation is at [Adding a workflow status badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge). The result is:

![Auto-update groups data](https://github.com/inventaire/isbn3/actions/workflows/auto_update_groups_data.yml/badge.svg)

You can also see the rendered `README.md`  at [my fork](https://github.com/marios-zindilis/isbn3).

Edit: Noting that `npm test` passes, although there are no changes in the JS code.