### PR TITLE
fix: issue in typings of `asIsbn10` and `asIsbn13`

### DIFF
--- a/isbn.d.ts
+++ b/isbn.d.ts
@@ -30,8 +30,8 @@ interface ISBN {
 
 declare module "isbn3" {
   export function parse(isbn: string): ISBN | null;
-  export function asIsbn13(isbn: string): string | null;
-  export function asIsbn10(isbn: string): string | null;
+  export function asIsbn13(isbn: string, hyphen?: boolean): string | null;
+  export function asIsbn10(isbn: string, hyphen?: boolean): string | null;
   export function hyphenate(isbn: string): string;
   export function audit(isbn: string): ISBNAudit;
   export const groups: Record<


### PR DESCRIPTION
Adds `hyphen` parameter into `asIsbn10` and `asIsbn13` signatures

Closes #22