### PR TITLE
types: differentiate isbn10 and isbn13

### DIFF
--- a/isbn.d.ts
+++ b/isbn.d.ts
@@ -9,29 +9,39 @@ interface ISBNAudit {
   }>;
 }
 
-interface ISBN {
+interface ISBNBase {
   source: string;
-  isValid: boolean;
-  isIsbn10: boolean;
-  isIsbn13: boolean;
-  prefix?: string;
+  isValid: true;
   group: string;
   publisher: string;
   article: string;
   check: string;
-  isbn13?: string;
-  isbn13h?: string;
-  check10: string;
-  check13: string;
   groupname: string;
-  isbn10?: string;
-  isbn10h?: string;
 }
+
+interface ISBN10 extends ISBNBase {
+  isIsbn10: true;
+  isIsbn13: false;
+  check10: string;
+  isbn10: string;
+  isbn10h: string;
+}
+
+interface ISBN13 extends ISBNBase {
+  isIsbn10: false;
+  isIsbn13: true;
+  prefix: string;
+  check13: string;
+  isbn13: string;
+  isbn13h: string;
+}
+
+type ISBN = ISBN10 | ISBN13;
 
 declare module "isbn3" {
   export function parse(isbn: string): ISBN | null;
-  export function asIsbn13(isbn: string): string | null;
-  export function asIsbn10(isbn: string): string | null;
+  export function asIsbn13(isbn: string, hyphen?: boolean): string | null;
+  export function asIsbn10(isbn: string, hyphen?: boolean): string | null;
   export function hyphenate(isbn: string): string;
   export function audit(isbn: string): ISBNAudit;
   export const groups: Record<


### PR DESCRIPTION
This commit improves the TypeScript type definitions by creating separate ISBN10 and ISBN13 interfaces instead of using a single ISBN interface with conflicting boolean flags. The new approach provides better type safety by ensuring that ISBN-10 and ISBN-13 specific properties are correctly typed and mutually exclusive.

The refactoring splits the original interface into two distinct types, where ISBN10 includes properties like isbn10, isbn10h, and check10, while ISBN13 includes prefix, isbn13, isbn13h, and check13. The parse function now returns ISBN10 | ISBN13 | null, providing clearer type discrimination for consumers of the library.